### PR TITLE
Post-finalization: Reject -let*(-values) forms with empty bodies

### DIFF
--- a/srfi/189.scm
+++ b/srfi/189.scm
@@ -667,15 +667,8 @@
 ;; gives a Nothing, the whole expression evaluates to Nothing.
 (define-syntax maybe-let*
   (syntax-rules ()
-    ((_ ()) (just unspecified))
     ((_ () expr1 expr2 ...)
      (call-with-values (lambda () expr1 expr2 ...) just))
-    ((_ ((_ maybe-expr))) (%guard-value maybe? maybe-expr))
-    ((_ ((maybe-expr))) (%guard-value maybe? maybe-expr))
-    ((_ (id))
-     (begin
-      (unless (maybe? id) (error "ill-typed value" maybe? id))
-      id))
     ((_ ((id maybe-expr) . claws) . body)
      (let ((maybe maybe-expr))
        (cond ((and (just? maybe) (singleton? (just-objs maybe)))
@@ -700,15 +693,8 @@
 ;; manner of let-values.
 (define-syntax maybe-let*-values
   (syntax-rules ()
-    ((_ ()) (just unspecified))
     ((_ () expr1 expr2 ...)
      (call-with-values (lambda () expr1 expr2 ...) just))
-    ((_ ((_ maybe-expr))) (%guard-value maybe? maybe-expr))
-    ((_ ((maybe-expr))) (%guard-value maybe? maybe-expr))
-    ((_ (id))
-     (begin
-      (unless (maybe? id) (error "ill-typed value" maybe? id))
-      id))
     ((_ (((id id* ...) maybe-expr) . claws) . body)
      (maybe-bind (%guard-value maybe? maybe-expr)
                  (lambda (id id* ...)
@@ -761,15 +747,8 @@
 ;; gives a Left, then the whole expression evaluates to that Left.
 (define-syntax either-let*
   (syntax-rules ()
-    ((_ ()) (right unspecified))
     ((_ () expr1 expr2 ...)
      (call-with-values (lambda () expr1 expr2 ...) right))
-    ((_ ((_ either-expr))) (%guard-value either? either-expr))
-    ((_ ((either-expr))) (%guard-value either? either-expr))
-    ((_ (id))
-     (begin
-      (unless (either? id) (error "ill-typed value" either? id))
-      id))
     ((_ ((id either-expr) . claws) . body)
      (let ((either either-expr))
        (cond ((and (right? either) (singleton? (right-objs either)))
@@ -794,15 +773,8 @@
 ;; manner of let-values.
 (define-syntax either-let*-values
   (syntax-rules ()
-    ((_ ()) (right unspecified))
     ((_ () expr1 expr2 ...)
      (call-with-values (lambda () expr1 expr2 ...) right))
-    ((_ ((_ either-expr))) (%guard-value either? either-expr))
-    ((_ ((either-expr))) (%guard-value either? either-expr))
-    ((_ (id))
-     (begin
-      (unless (either? id) (error "ill-typed value" either? id))
-      id))
     ((_ (((id id* ...) either-expr) . claws) . body)
      (either-bind (%guard-value either? either-expr)
                   (lambda (id id* ...)

--- a/test-syntax.scm
+++ b/test-syntax.scm
@@ -39,9 +39,6 @@
   (check (nothing? (maybe-or (nothing) (nothing) (nothing))) => #t)
   (check (raises-error-object (maybe-or (nothing) #t))       => #t)
 
-  (check (just? (maybe-let* ())) => #t)
-  (check (just-of-z? (maybe-let* (((just 'z))))) => #t)
-  (check (just-of-z? (maybe-let* ((x (just 'z))))) => #t)
   (check (just-of-z?
           (maybe-let* (((maybe-bind (just #t) just)))
             'z)) => #t)
@@ -77,7 +74,6 @@
     (check (just-of-z? (maybe-let* (just-of-z ((just 'x)))
                          'z))
      => #t)
-    (check (nothing? (maybe-let* (zilch))) => #t)
     (check (nothing? (maybe-let* ((x (just 2)) zilch (y (just 3)))
                        (* x y)))
      => #t))
@@ -98,9 +94,6 @@
            (maybe-let* ((b (just #t)) ('nothing)) #t))
     => #t)
 
-  (check (just? (maybe-let*-values ())) => #t)
-  (check (just-of-z? (maybe-let*-values (((just 'z))))) => #t)
-  (check (just-of-z? (maybe-let*-values (((x) (just 'z))))) => #t)
   (check (just-of-z?
           (maybe-let*-values (((maybe-bind (just #t) just)))
             'z)) => #t)
@@ -149,7 +142,6 @@
     (check (just-of-z? (maybe-let*-values (just-of-z ((just 'x)))
                          'z))
      => #t)
-    (check (nothing? (maybe-let*-values (zilch))) => #t)
     (check (nothing? (maybe-let*-values (((x) (just 2))
                                          zilch
                                          ((y) (just 3)))
@@ -201,9 +193,6 @@
   (check (left-of-z? (either-or (left) (left) (left 'z))) => #t)
   (check (raises-error-object (either-or (left #f) #t))   => #t)
 
-  (check (right? (either-let* ())) => #t)
-  (check (right-of-z? (either-let* (((right 'z))))) => #t)
-  (check (right-of-z? (either-let* ((x (right 'z))))) => #t)
   (check (right-of-z?
           (either-let* (((either-bind (right #t) right)))
             'z))
@@ -240,7 +229,6 @@
             (either-let* (right-of-z ((right 'x)))
               'z))
      => #t)
-    (check (left-of-z? (either-let* (left-of-z))) => #t)
     (check (left-of-z?
             (either-let* ((x (right 2)) left-of-z (y (right 3)))
               (* x y)))
@@ -262,9 +250,6 @@
           (either-let* ((b (right #t)) ('left)) #t))
     => #t)
 
-  (check (right? (either-let*-values ())) => #t)
-  (check (right-of-z? (either-let*-values (((right 'z))))) => #t)
-  (check (right-of-z? (either-let*-values (((x) (right 'z))))) => #t)
   (check (right-of-z?
           (either-let*-values (((either-bind (right #t) right)))
             'z))
@@ -316,7 +301,6 @@
     (check (right-of-z? (either-let*-values (right-of-z ((right 'x)))
                           'z))
      => #t)
-    (check (left-of-z? (either-let*-values (left-of-z))) => #t)
     (check (left-of-z? (either-let*-values (((x) (right 2))
                                             left-of-z
                                             ((y) (right 3)))


### PR DESCRIPTION
The commit to be merged amends the sample implementation to reject maybe/either-let*(-values) forms with empty body components, following the more recent semantics for these forms in the SRFI document. Thanks.